### PR TITLE
fix: use root user for yum updates

### DIFF
--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -5,7 +5,7 @@ WORKDIR /opt/app-root/src
 
 COPY Pipfile* /opt/app-root/src/
 
-
+USER root
 RUN yum -y install --disableplugin=subscription-manager wget \
   && yum --disableplugin=subscription-manager clean all
 


### PR DESCRIPTION
Only affects `Dockerfile-tools` used by CLI `dev build`.